### PR TITLE
Undo projection matrix in auto-stereo mode

### DIFF
--- a/src/libANGLE/Shader.cpp
+++ b/src/libANGLE/Shader.cpp
@@ -302,9 +302,9 @@ void Shader::compile(Compiler *compiler)
             size_t index2 = sourceString.find_last_of('}');
             std::string modifiedSourceString = 
                 sourceString.substr(0, index1) + 
-                "uniform mat4 uHolographicViewMatrix[2];\n uniform mat4 uHolographicProjectionMatrix[2];\n uniform mat4 uHolographicViewProjectionMatrix[2];\n uniform mat4 uUndoMidViewMatrix;\n out float vRenderTargetArrayIndex;\n " +
+                "uniform mat4 uHolographicViewMatrix[2];\n uniform mat4 uHolographicProjectionMatrix[2];\n uniform mat4 uHolographicViewProjectionMatrix[2];\n uniform mat4 uUndoMidViewProjMatrix;\n out float vRenderTargetArrayIndex;\n " +
                 sourceString.substr(index1, index2-index1) +
-                " int index = gl_InstanceIDUnmodified - (gl_InstanceID*2);\n vRenderTargetArrayIndex = float(index);\n gl_Position = uHolographicProjectionMatrix[index] * uHolographicViewMatrix[index] * uUndoMidViewMatrix * gl_Position;\n " +
+                " int index = gl_InstanceIDUnmodified - (gl_InstanceID*2);\n vRenderTargetArrayIndex = float(index);\n gl_Position = uHolographicProjectionMatrix[index] * uHolographicViewMatrix[index] * uUndoMidViewProjMatrix * gl_Position;\n " +
                 sourceString.substr(index2);
             sourceString = modifiedSourceString;
         }

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.h
@@ -172,10 +172,11 @@ class HolographicSwapChain11 : public SwapChainD3D
     // orientation within the coordinate system provided by the app.
     static DirectX::XMFLOAT4X4          mViewMatrices[2];
     static DirectX::XMFLOAT4X4          mMidViewMatrix;
-    static DirectX::XMFLOAT4X4          mMidViewMatrixInverse;
 
     static DirectX::XMFLOAT4X4          mProjectionMatrices[2];
     static DirectX::XMFLOAT4X4          mMidProjectionMatrix;
+
+    static DirectX::XMFLOAT4X4          mMidViewProjMatrixInverse;
 
     // Tracks whether or not the app has enabled automatic stereo instancing.
     static bool                         mUseAutomaticStereoRendering;


### PR DESCRIPTION
Allow applications to render using the projection matrix provided by the framework (in addition to view matrix), and account for this in automatic stereo mode. Enables more seamless and generic support for libraries which tie features like frustum culling to their projection matrix.