### PR TITLE
Fix holographic view matrices

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -604,18 +604,6 @@ EGLint HolographicSwapChain11::updateHolographicRenderingParameters()
                 {
                     ComputeMidViewMatrix(leftViewMatrix, rightViewMatrix);
                 }
-                
-                // TODO: The display was being mirrored, so for now we hack these values to 
-                //       negative as far as the app is concerned.
-                viewTransform.Left.M11 = -viewTransform.Left.M11;
-                viewTransform.Left.M12 = -viewTransform.Left.M12;
-                viewTransform.Left.M13 = -viewTransform.Left.M13;
-                viewTransform.Right.M11 = -viewTransform.Right.M11;
-                viewTransform.Right.M12 = -viewTransform.Right.M12;
-                viewTransform.Right.M13 = -viewTransform.Right.M13;
-                mMidViewMatrix._11 = -mMidViewMatrix._11;
-                mMidViewMatrix._12 = -mMidViewMatrix._12;
-                mMidViewMatrix._13 = -mMidViewMatrix._13;
 
                 // store view matrix
                 DirectX::XMStoreFloat4x4(


### PR DESCRIPTION
Expose correct view matrix suitable for apps to use for their own calculations (e.g. scene graph, frustum culling) Fixes Microsoft/HoloJS#87.