### PR TITLE
Fix undoing the ViewProjection matrix and upgrade to VS 2017

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -715,7 +715,14 @@ EGLint HolographicSwapChain11::updateHolographicRenderingParameters()
                     if (mUseAutomaticStereoRendering)
                     {
                         DirectX::XMVECTOR determinant;
-                        auto viewProjInverse = XMMatrixInverse(&determinant, XMLoadFloat4x4(viewProj));
+						DirectX::XMFLOAT4X4 midViewProj;
+						DirectX::XMStoreFloat4x4(
+							&midViewProj,
+							DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidViewMatrix)) *
+							DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidProjectionMatrix))
+						);
+
+                        auto viewProjInverse = XMMatrixInverse(&determinant, XMLoadFloat4x4(&midViewProj));
 
                         if (!XMVector4NearEqual(determinant, XMVectorZero(), XMVectorSplatEpsilon()))
                         {

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -715,12 +715,12 @@ EGLint HolographicSwapChain11::updateHolographicRenderingParameters()
                     if (mUseAutomaticStereoRendering)
                     {
                         DirectX::XMVECTOR determinant;
-						DirectX::XMFLOAT4X4 midViewProj;
-						DirectX::XMStoreFloat4x4(
-							&midViewProj,
-							DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidViewMatrix)) *
-							DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidProjectionMatrix))
-						);
+                        DirectX::XMFLOAT4X4 midViewProj;
+                        DirectX::XMStoreFloat4x4(
+                            &midViewProj,
+                            DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidViewMatrix)) *
+                            DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(&mMidProjectionMatrix))
+                        );
 
                         auto viewProjInverse = XMMatrixInverse(&determinant, XMLoadFloat4x4(&midViewProj));
 

--- a/winrt/10/src/angle_common.vcxproj
+++ b/winrt/10/src/angle_common.vcxproj
@@ -35,8 +35,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />

--- a/winrt/10/src/commit_id.vcxproj
+++ b/winrt/10/src/commit_id.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -313,7 +313,7 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\angle.gyp" />
     <None Include="..\..\..\.git\index">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </None>
@@ -321,7 +321,8 @@
   <ItemGroup>
     <CustomBuild Include="$(OutDir)obj\global_intermediate\angle\commit_id.bat">
       <FileType>Document</FileType>
-      <Command>call call &quot;$(OutDir)obj\global_intermediate\angle\commit_id.bat&quot; &quot;..\..\..\src\gen&quot; &quot;..\..\..&quot; &quot;$(OutDir)obj\global_intermediate\angle\id\commit.h&quot;&#xD;&#xA;if %errorlevel% neq 0 exit /b %errorlevel%</Command>
+      <Command>call call "$(OutDir)obj\global_intermediate\angle\commit_id.bat" "..\..\..\src\gen" "..\..\.." "$(OutDir)obj\global_intermediate\angle\id\commit.h"
+if %errorlevel% neq 0 exit /b %errorlevel%</Command>
       <Message>Generating ANGLE Commit ID</Message>
       <Outputs>$(OutDir)obj\global_intermediate\angle\id\commit.h</Outputs>
       <AdditionalInputs>..\..\..\.git\index</AdditionalInputs>
@@ -333,7 +334,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/winrt/10/src/commit_id.vcxproj.filters
+++ b/winrt/10/src/commit_id.vcxproj.filters
@@ -45,11 +45,11 @@
     <None Include="..\..\..\src\angle.gyp">
       <Filter>..\..\..\src</Filter>
     </None>
-    <None Include="$(OutDir)obj\global_intermediate\angle\commit_id.bat">
-      <Filter>$(OutDir)obj\global_intermediate\angle\_excluded_files</Filter>
-    </None>
     <None Include="..\..\..\.git\index">
       <Filter>..\..\..\.git\_excluded_files</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="$(OutDir)obj\global_intermediate\angle\commit_id.bat" />
   </ItemGroup>
 </Project>

--- a/winrt/10/src/copy_compiler_dll.vcxproj
+++ b/winrt/10/src/copy_compiler_dll.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -313,7 +313,7 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\angle.gyp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="copy_scripts.vcxproj">
@@ -321,7 +321,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/winrt/10/src/copy_scripts.vcxproj
+++ b/winrt/10/src/copy_scripts.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -313,23 +313,25 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\angle.gyp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\..\src\commit_id.bat">
       <FileType>Document</FileType>
-      <Command>call mkdir &quot;$(OutDir)obj\global_intermediate\angle&quot; 2&gt;nul &amp; set ERRORLEVEL=0 &amp; copy /Y &quot;..\..\..\src\commit_id.bat&quot; &quot;$(OutDir)obj\global_intermediate\angle\commit_id.bat&quot;&#xD;&#xA;if %errorlevel% neq 0 exit /b %errorlevel%</Command>
+      <Command>call mkdir "$(OutDir)obj\global_intermediate\angle" 2&gt;nul &amp; set ERRORLEVEL=0 &amp; copy /Y "..\..\..\src\commit_id.bat" "$(OutDir)obj\global_intermediate\angle\commit_id.bat"
+if %errorlevel% neq 0 exit /b %errorlevel%</Command>
       <Message>Copying commit_id.bat to $(OutDir)obj/global_intermediate/angle\commit_id.bat</Message>
       <Outputs>$(OutDir)obj\global_intermediate\angle\commit_id.bat</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\..\..\src\copy_compiler_dll.bat">
       <FileType>Document</FileType>
-      <Command>call mkdir &quot;$(OutDir)obj\global_intermediate\angle&quot; 2&gt;nul &amp; set ERRORLEVEL=0 &amp; copy /Y &quot;..\..\..\src\copy_compiler_dll.bat&quot; &quot;$(OutDir)obj\global_intermediate\angle\copy_compiler_dll.bat&quot;&#xD;&#xA;if %errorlevel% neq 0 exit /b %errorlevel%</Command>
+      <Command>call mkdir "$(OutDir)obj\global_intermediate\angle" 2&gt;nul &amp; set ERRORLEVEL=0 &amp; copy /Y "..\..\..\src\copy_compiler_dll.bat" "$(OutDir)obj\global_intermediate\angle\copy_compiler_dll.bat"
+if %errorlevel% neq 0 exit /b %errorlevel%</Command>
       <Message>Copying copy_compiler_dll.bat to $(OutDir)obj/global_intermediate/angle\copy_compiler_dll.bat</Message>
       <Outputs>$(OutDir)obj\global_intermediate\angle\copy_compiler_dll.bat</Outputs>
     </CustomBuild>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/winrt/10/src/libANGLE.vcxproj
+++ b/winrt/10/src/libANGLE.vcxproj
@@ -35,8 +35,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />

--- a/winrt/10/src/libEGL.vcxproj
+++ b/winrt/10/src/libEGL.vcxproj
@@ -35,8 +35,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />

--- a/winrt/10/src/libGLESv2.vcxproj
+++ b/winrt/10/src/libGLESv2.vcxproj
@@ -35,8 +35,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />

--- a/winrt/10/src/preprocessor.vcxproj
+++ b/winrt/10/src/preprocessor.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -313,40 +313,40 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\compiler\preprocessor\ExpressionParser.y"/>
-    <None Include="..\..\..\src\compiler\preprocessor\Tokenizer.l"/>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\compiler\preprocessor\ExpressionParser.y" />
+    <None Include="..\..\..\src\compiler\preprocessor\Tokenizer.l" />
+    <None Include="..\..\..\src\angle.gyp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\DiagnosticsBase.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\DirectiveHandlerBase.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\DirectiveParser.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\ExpressionParser.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Input.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Lexer.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Macro.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\MacroExpander.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Preprocessor.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\SourceLocation.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Token.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\Tokenizer.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\numeric_lex.h"/>
-    <ClInclude Include="..\..\..\src\compiler\preprocessor\pp_utils.h"/>
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\DiagnosticsBase.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\DirectiveHandlerBase.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\DirectiveParser.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\ExpressionParser.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Input.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Lexer.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Macro.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\MacroExpander.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Preprocessor.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\SourceLocation.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Token.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\Tokenizer.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\numeric_lex.h" />
+    <ClInclude Include="..\..\..\src\compiler\preprocessor\pp_utils.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\DiagnosticsBase.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\DirectiveHandlerBase.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\DirectiveParser.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\ExpressionParser.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Input.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Lexer.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Macro.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\MacroExpander.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Preprocessor.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Token.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\preprocessor\Tokenizer.cpp"/>
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\DiagnosticsBase.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\DirectiveHandlerBase.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\DirectiveParser.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\ExpressionParser.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Input.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Lexer.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Macro.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\MacroExpander.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Preprocessor.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Token.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\preprocessor\Tokenizer.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/winrt/10/src/translator.vcxproj
+++ b/winrt/10/src/translator.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -325,13 +325,13 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\angle.gyp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\compiler\translator\ShaderLang.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\translator\ShaderVars.cpp"/>
+    <ClCompile Include="..\..\..\src\compiler\translator\ShaderLang.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\translator\ShaderVars.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/winrt/10/src/translator_lib.vcxproj
+++ b/winrt/10/src/translator_lib.vcxproj
@@ -35,8 +35,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,7 +44,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />

--- a/winrt/10/src/translator_static.vcxproj
+++ b/winrt/10/src/translator_static.vcxproj
@@ -35,24 +35,24 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <ExecutablePath>$(ExecutablePath);$(MSBuildProjectDirectory)\..\..\..\third_party\cygwin\bin\;$(MSBuildProjectDirectory)\..\..\..\third_party\python_26\</ExecutablePath>
     <OutDir>$(SolutionDir)$(Configuration)_$(Platform)\</OutDir>
@@ -325,13 +325,13 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\..\..\src\angle.gyp"/>
+    <None Include="..\..\..\src\angle.gyp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\compiler\translator\ShaderLang.cpp"/>
-    <ClCompile Include="..\..\..\src\compiler\translator\ShaderVars.cpp"/>
+    <ClCompile Include="..\..\..\src\compiler\translator\ShaderLang.cpp" />
+    <ClCompile Include="..\..\..\src\compiler\translator\ShaderVars.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>


### PR DESCRIPTION
For auto-stereo, the mid view projection matrix is mid-View * midProjection (right projection)

This mid matrix needs to be undone in the shader for auto-stereo so we multiply with the inverse. However, the inverse was computed as left view * left projection. 

Usually the left and right projection are very similar so it's close enough, but during MRC, the right projection matrix is vastly different than the left one to account for overrendering. This leads to weird swimming of objects.

Also upgrade to VS 2017 and minimum supported version in ANGLE to RS1.